### PR TITLE
fix: Only require scnvim module when needed, to allow lazy loading

### DIFF
--- a/lua/telescope/_extensions/scdoc/main.lua
+++ b/lua/telescope/_extensions/scdoc/main.lua
@@ -9,17 +9,15 @@ local defaulter = ts_utils.make_default_callable
 
 local uv = vim.loop
 local api = vim.api
-local scnvim = require'scnvim'
-local help = require'scnvim.help'
 local path_sep = '/'
 
 local M = {}
 local doc_map = nil
 
 local function generate(callback)
-  scnvim.eval('SCDoc.helpTargetDir', function(dir)
+  require"scnvim".eval('SCDoc.helpTargetDir', function(dir)
     local path = dir .. path_sep .. 'docmap.json'
-    local ok, docmap = pcall(help.get_docmap, path)
+    local ok, docmap = pcall(require"scnvim.help".get_docmap, path)
     if not ok then
       error(docmap)
     end
@@ -117,7 +115,7 @@ M.list = function(opts)
         actions.select_default:replace(function()
           actions.close(prompt_bufnr)
           local selection = action_state.get_selected_entry()
-          help.open_help_for(selection.value.title)
+          require"scnvim.help".open_help_for(selection.value.title)
         end)
         return true
       end,


### PR DESCRIPTION
Hi! This small PR moves the require'ing of scnvim into the functions themselves. This allows lazyloading telescope-scdoc more easily, not being too dependent on scnvim and telescope being loaded in the perfect order and at startup. 